### PR TITLE
[TDt-4] Update redis-store

### DIFF
--- a/redis-activesupport.gemspec
+++ b/redis-activesupport.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'redis-store',   '~> 1.1.0'
+  s.add_runtime_dependency 'redis-store',   '~> 1.4.0'
   s.add_runtime_dependency 'activesupport', '~> 3.2.0'
 
   s.add_development_dependency 'rake',     '~> 10'


### PR DESCRIPTION
Update redis-store to patch a vulnerability. We forked this gem because
the redis-store version that contains a fix for the vulnerability, is
not quite compatible with other dependencies.

